### PR TITLE
[Release] v0.1.1

### DIFF
--- a/docker/install/ubuntu_install_conda.sh
+++ b/docker/install/ubuntu_install_conda.sh
@@ -14,12 +14,13 @@ sh /tmp/install.sh -b
 
 CONDA_PREFIX=$HOME/miniconda3/bin
 export PATH=$CONDA_PREFIX:$PATH
-for PY_VER in 3.6.4 3.7.0; do
+for PY_VER in 3.5 3.6 3.7; do
   echo "Create conda env for python $PY_VER"
   conda create -n $PY_VER -y python=$PY_VER
   source activate $PY_VER
-  conda install -y $TF==2.0 pytest
-  echo conda install -y $TH -c pytorch
+  pip install --upgrade pip
+  pip install $TF==2.0
+  conda install -y pytest
   conda install -y $TH -c pytorch
   source deactivate
 done

--- a/python/tfdlpack/libinfo.py
+++ b/python/tfdlpack/libinfo.py
@@ -86,4 +86,4 @@ def find_lib_path(name=None, search_path=None, optional=False):
 # We use the version of the incoming release for code
 # that is under development.
 # The following line is set by tfdlpack/python/update_version.py
-__version__ = "0.1"
+__version__ = "0.1.1"

--- a/tests/scripts/build_in_docker.sh
+++ b/tests/scripts/build_in_docker.sh
@@ -14,7 +14,7 @@ CONDA_PREFIX=$HOME/miniconda3/bin
 export PATH=$CONDA_PREFIX:$PATH
 export PYTHONPATH=$PWD/python:$PYTHONPATH
 export TFDLPACK_LIBRARY_PATH=$PWD/build
-for PY_VER in 3.6.4 3.7.0; do
+for PY_VER in 3.5 3.6 3.7; do
   echo "Build for python $PY_VER"
   source activate $PY_VER
   # clean & build


### PR DESCRIPTION
This fixes issue #8 . The cause is we build our library against the tensorflow hosted by conda. It turns out that conda's tensorflow uses new CXX11 ABI while the official tensorflow (accessible using pip install) uses old ABI, which causes the error. This PR switches the tensorflow from conda's to the official one because tfdlpack currently does not support conda install.

The PR also enables tfdlpack on python 3.5.